### PR TITLE
Update Go version to 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.22'
           check-latest: true
 
       - name: Install dependencies
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.22'
           check-latest: true
 
       - name: golangci-lint
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.22'
           check-latest: true
 
       - name: Build
@@ -64,4 +64,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pr-status-checker
-          path: pr-status-checker 
+          path: pr-status-checker


### PR DESCRIPTION
このPRでは以下の変更を行います：

- CIワークフローのGoバージョンを1.24から1.22に更新
- すべてのジョブ（test、lint、build）でGoバージョン1.22を使用するように設定

これにより、プロジェクトの安定性と互換性が向上します。